### PR TITLE
Prevent claimYield from overriding existing delegation

### DIFF
--- a/src/Bread.sol
+++ b/src/Bread.sol
@@ -110,7 +110,7 @@ contract Bread is
         if (yield < amount) revert YieldInsufficient();
 
         _mint(receiver, amount);
-        _delegate(receiver, receiver);
+        if (this.delegates(receiver) == address(0)) _delegate(receiver, receiver);
 
         emit ClaimedYield(amount);
     }


### PR DESCRIPTION
Currently any owner or yieldClaimer can over ride someone's existing delegation. This implements a check to stop that. 

PR includes the fix and a test to illustrate the scenario